### PR TITLE
fix: correction in Readme.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,5 +84,5 @@ dbQues: List of SQL/DB-based questions to skip
 
 Run the script with Node:
 ```
-node script.js
+node ok.js
 ```


### PR DESCRIPTION
At the end of the **Readme.md** to execute the repo run the command `node script.js`, but the correct command should be `node ok.js`, because `_script.js_` file doesn't exist.