### PR TITLE
feat: add local Chrome extension for LeetCode token retrieval

### DIFF
--- a/LeetCode-Token-Viewer/manifest.json
+++ b/LeetCode-Token-Viewer/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "LeetCode Token Viewer",
+  "description": "Displays your LeetCode session and CSRF tokens locally for manual use.",
+  "version": "1.0",
+  "manifest_version": 3,
+  "permissions": ["cookies", "activeTab", "scripting"],
+  "host_permissions": ["https://leetcode.com/*"],
+  "action": {
+    "default_popup": "popup.html"
+  }
+}

--- a/LeetCode-Token-Viewer/popup.html
+++ b/LeetCode-Token-Viewer/popup.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>LeetCode Token Viewer</title>
+    <style>
+      body {
+        font-family: "Segoe UI", sans-serif;
+        background: #f5f7fa;
+        margin: 0;
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        width: 280px;
+      }
+
+      h1 {
+        font-size: 16px;
+        margin-bottom: 10px;
+        color: #333;
+      }
+
+      .token-box {
+        background: #fff;
+        border: 1px solid #ccc;
+        border-radius: 8px;
+        padding: 15px;
+        width: 100%;
+        box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+        word-break: break-all;
+        font-size: 13px;
+        color: #444;
+      }
+
+      .label {
+        font-weight: bold;
+        color: #000;
+      }
+
+      button {
+        margin-top: 15px;
+        background: #007bff;
+        color: white;
+        border: none;
+        padding: 8px 12px;
+        border-radius: 6px;
+        cursor: pointer;
+        font-size: 13px;
+        transition: 0.2s;
+      }
+
+      button:hover {
+        background: #0056b3;
+      }
+
+      #status {
+        margin-top: 10px;
+        font-size: 12px;
+        color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>🔐 LeetCode Token Viewer</h1>
+    <div id="token" class="token-box">Fetching tokens...</div>
+    <button id="copy">Copy Tokens</button>
+    <div id="status"></div>
+
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/LeetCode-Token-Viewer/popup.js
+++ b/LeetCode-Token-Viewer/popup.js
@@ -1,0 +1,34 @@
+async function getLeetCodeTokens() {
+  try {
+    const cookies = await chrome.cookies.getAll({ domain: "leetcode.com" });
+    const session = cookies.find(c => c.name === "LEETCODE_SESSIreON");
+    const csrftoken = cookies.find(c => c.name === "csrftoken");
+
+    const tokenBox = document.getElementById("token");
+    const status = document.getElementById("status");
+    const copyBtn = document.getElementById("copy");
+
+    if (session && csrftoken) {
+      const formatted = `
+        <div><span class="label">Session:</span> ${session.value}</div>
+        <div><span class="label">CSRF Token:</span> ${csrftoken.value}</div>
+      `;
+      tokenBox.innerHTML = formatted;
+
+      copyBtn.onclick = () => {
+        const tokenString = `session=${session.value}; csrftoken=${csrftoken.value}`;
+        navigator.clipboard.writeText(tokenString);
+        status.textContent = "✅ Tokens copied!";
+        setTimeout(() => status.textContent = "", 2000);
+      };
+    } else {
+      tokenBox.textContent = "⚠️ Please log in to leetcode.com first.";
+      copyBtn.disabled = true;
+    }
+  } catch (err) {
+    console.error("Error fetching cookies:", err);
+    document.getElementById("token").textContent = "Error fetching tokens.";
+  }
+}
+
+getLeetCodeTokens();

--- a/README.md
+++ b/README.md
@@ -16,9 +16,16 @@ This Node.js script automates fetching solved LeetCode problems, retrieves corre
 
 - Tracks progress in progress.json
 
-## Project Structure
+- **New:** Chrome Extension to easily fetch LeetCode session and CSRF tokens
+
+
+##New Project Structure
 ```
 project/
+├── LeetCode-Token-Viewer
+    ├── manifest.json
+    ├── popup.html
+    ├── popup.js
 ├── ok.js             # Your main Node.js script
 ├── merged_output.json    # Contains problem info (id, walkcc_url, leetcode_url)
 ├── progress.json         # Tracks submitted questions
@@ -36,6 +43,38 @@ npm -v
 npm install fs-extra
 ```
 
+## LeetCode Token Viewer Chrome Extension
+
+This Chrome Extension helps you fetch your LeetCode session and CSRF tokens locally.
+
+### Features
+
+- Extracts LEETCODE_SESSION and csrftoken from your browser cookies
+
+- Displays tokens in a simple popup
+
+- Lets you copy tokens as a single string (e.g., session:<value>; csrf:<value>)
+
+- Fully local — never sends your tokens anywhere
+
+### Installation
+
+- Open Chrome and go to chrome://extensions.
+
+- Enable Developer mode (toggle in top-right corner).
+
+- Click Load unpacked and select the leetcode-token-viewer folder.
+
+- Pin the extension to the Chrome toolbar for easy access.
+
+### Usage
+
+- Log in to LeetCode.
+
+- Click the LeetCode Token Viewer extension icon.
+
+- Copy the token string displayed:
+
 ## Update Credentials in Script
 
 Fill in these fields at the top of the file:
@@ -43,26 +82,6 @@ Fill in these fields at the top of the file:
 const LEETCODE_SESSION = "<your-session-cookie>";
 const CSRFTOKEN = "<your-csrf-token>";
 ```
-#### How to get them (Chrome browser):
-
-- [Install this extension:](https://chromewebstore.google.com/detail/cookie-editor/iphcomljdfghbkdcfndaijbokpgddeno)
-
-- Log in to https://leetcode.com
-
-- Open the Cookie Editor
-
-- Copy the values of:
-```
-LEETCODE_SESSION
-csrftoken
-```
-
-Paste them into the script here:
-```
-LEETCODE_SESSION = ""
-CSRFTOKEN = ""
-```
-
 
 ## How It Works
 - Constants


### PR DESCRIPTION
Added a local Chrome extension to fetch the LeetCode session and CSRF tokens.
The extension displays both tokens in a single string for easy copy-pasting.
Tokens remain fully local and are never shared externally.
Attached the screeshots for the reference:-
<img width="243" height="175" alt="Screenshot from 2025-10-22 12-11-57" src="https://github.com/user-attachments/assets/fa4e062e-d43b-4062-8243-6efc40974399" />
<img width="659" height="479" alt="Screenshot from 2025-10-22 12-11-39" src="https://github.com/user-attachments/assets/316e59fa-9beb-4011-a6cb-8753fd4bd8aa" />
