### PR TITLE
refactor: Remove fs-extra dependency, use native fs

### DIFF
--- a/ok.js
+++ b/ok.js
@@ -1,4 +1,4 @@
-const fs = require("fs-extra");
+const fs = require("fs");
 const path = require("path");
 const readline = require('readline');
 const mergedData = require('./merged_output.json'); //require loads at compile time ...fs loads in runtime

--- a/package.json
+++ b/package.json
@@ -1,5 +1,1 @@
-{
-  "dependencies": {
-    "fs-extra": "^11.3.2"
-  }
-}
+{}


### PR DESCRIPTION
Closes #21

This PR removes the unnecessary `fs-extra` dependency. 

The file `ok.js` was only using functions (`existsSync`, `readFileSync`, `writeFileSync`, `appendFileSync`) that are already available in the native Node.js `fs` module. I updated the `require` statement to use the native `fs` module and uninstalled the `fs-extra` package.